### PR TITLE
Make the dub commands play nice with Windows.

### DIFF
--- a/lib/d-struct.coffee
+++ b/lib/d-struct.coffee
@@ -1,19 +1,25 @@
 # Grab a few objects that we'll need
 popen = require('child_process').exec
-path = require('path')
 platform = require('os').platform
+
+# TODO: linux support still needs to be added
+commands =
+    build:
+        win32: "start cmd /k \"cd #{atom.project.getPaths().shift()} && dub run\""
+        darwin: "osascript -e \'tell application \"Terminal\" to do script \"cd #{atom.project.getPaths().shift()}; dub run\"\'"
+    run:
+        win32: "start cmd /k \"cd \"#{atom.project.getPaths().shift()}\" && dub build\""
+        darwin: "osascript -e \'tell application \"Terminal\" to do script \"cd #{atom.project.getPaths().shift()}; dub build\"\'"
 
 # Open a terminal and run dub
 dub_build = ->
   # Run the terminal app
-  cmdline = "osascript -e \'tell application \"Terminal\" to do script \"cd #{atom.project.path}; dub build\"\'"
-  popen cmdline
+  popen commands.build[platform()] if platform() of commands.build
 
 # Open a terminal and run the app with dub
 dub_run = ->
   # Run the terminal app
-  cmdline = "osascript -e \'tell application \"Terminal\" to do script \"cd #{atom.project.path}; dub run\"\'"
-  popen cmdline
+  popen commands.run[platform()] if platform() of commands.run
 
 module.exports =
   # Bind workspace command to run_dub


### PR DESCRIPTION
* The dub build/run commands are now compatible with Windows as well as OS X.
* Fix code to get project path.
* Remove the path import since it's not needed.