### PR TITLE
Use line comments instead of block comments

### DIFF
--- a/settings/d-struct.cson
+++ b/settings/d-struct.cson
@@ -1,0 +1,3 @@
+'.source.d':
+  'editor':
+    'commentStart': '// '


### PR DESCRIPTION
When you use the editor:toggle-line-comments shortcut, Atom will comment out the selection in accordance with the commentStart and commentEnd settings specified for the scope.  Typically, e.g. for language-c, language-coffee-script, etc, this triggers the language-appropriate single-line comment, even if you have multiple lines selected.  This is usually desired, because even if you decide to comment out the lines in a block now, you may want to selectively uncomment them later.

However, if the scope fails to specify a commenting scheme, Atom will fall back on the default /* ... */ block comment, chosen presumably for being more universal, but inconvenient because it is a block comment.  This PR rectifies this in accordance with the rest of the Atom grammars by specifying what D uses for its line comments.